### PR TITLE
Most popular Polish newspapers and magazines

### DIFF
--- a/_data/websites.json
+++ b/_data/websites.json
@@ -306,6 +306,96 @@
         "country": "🇫🇷"
     },
     {
+        "category": "press",
+        "name": "Fakt",
+        "domain": "fakt.pl",
+        "country": "🇵🇱"
+    },
+    {
+        "category": "press",
+        "name": "Super Express",
+        "domain": "www.se.pl",
+        "country": "🇵🇱"
+    },
+    {
+        "category": "press",
+        "name": "Gazeta Wyborcza",
+        "domain": "wyborcza.pl",
+        "country": "🇵🇱"
+    },
+    {
+        "category": "press",
+        "name": "Rzeczpospolita",
+        "domain": "www.rp.pl",
+        "country": "🇵🇱"
+    },
+    {
+        "category": "press",
+        "name": "Dziennik Gazeta Prawna",
+        "domain": "www.gazetaprawna.pl",
+        "country": "🇵🇱"
+    },
+    {
+        "category": "press",
+        "name": "Polityka",
+        "domain": "www.polityka.pl",
+        "country": "🇵🇱"
+    },
+    {
+        "category": "press",
+        "name": "Newsweek Polska",
+        "domain": "www.newsweek.pl",
+        "country": "🇵🇱"
+    },
+    {
+        "category": "press",
+        "name": "Gość Niedzielny",
+        "domain": "www.gosc.pl",
+        "country": "🇵🇱"
+    },
+    {
+        "category": "press",
+        "name": "Sieci",
+        "domain": "www.sieciprawdy.pl",
+        "country": "🇵🇱"
+    },
+    {
+        "category": "press",
+        "name": "Do Rzeczy",
+        "domain": "dorzeczy.pl",
+        "country": "🇵🇱"
+    },
+    {
+        "category": "press",
+        "name": "Twój Styl",
+        "domain": "twojstyl.pl",
+        "country": "🇵🇱"
+    },
+    {
+        "category": "press",
+        "name": "Zwierciadło",
+        "domain": "zwierciadlo.pl",
+        "country": "🇵🇱"
+    },
+    {
+        "category": "press",
+        "name": "Wysokie Obcasy Extra",
+        "domain": "www.wysokieobcasy.pl",
+        "country": "🇵🇱"
+    },
+    {
+        "category": "press",
+        "name": "Pani",
+        "domain": "pani.pl",
+        "country": "🇵🇱"
+    },
+    {
+        "category": "press",
+        "name": "Elle",
+        "domain": "www.elle.pl",
+        "country": "🇵🇱"
+    },
+    {
         "category": "video on demand",
         "name": "Prime Video",
         "domain": "www.primevideo.com",


### PR DESCRIPTION
PR contains a list of the most popular newspapers and magazines in Poland with original content. As a rule of thumb, I choose the ones whose issues are sold in more than 25 000 copies (on average).

Source (in Polish):
- newspapers (2023): <https://www.wirtualnemedia.pl/artykul/fakt-na-czele-sprzedazy-w-2023-roku-gazeta-wyborcza-stracila-najwiecej>
- weekly newspapers (2023): <https://www.wirtualnemedia.pl/artykul/sprzedaz-tygodnikow-opinii-iii-kwartal-2023-polityka-newsweek-polska>
- magazines (2023): <https://www.wirtualnemedia.pl/artykul/sprzedaz-miesieczniki-luksusowe-shoppingowe-iii-kwartal-2023>