### PR TITLE
block more spam scrapers

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ User-agent: CCBot
 User-agent: Omgilibot
 User-agent: Omgili
 
+# Facebook: LLaMA2
+User-agent: FacebookBot
+
 # ByteDance: Duobao
 User-agent: Bytespider
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ User-agent: anthropic-ai
 # Common Crawl
 User-agent: CCBot
 
+# Omglibot: webz.io
+User-agent: Omgilibot
+User-agent: Omgili
+
+# ByteDance: Duobao
+User-agent: Bytespider
+
 # Censorship area
 Disallow: /
 ```

--- a/scrape.py
+++ b/scrape.py
@@ -28,8 +28,12 @@ def scrape_websites(websites):
 
             blocked = "gptbot" in body \
                 or "chatgpt-user" in body \
+                or "google-extended" in body \
                 or "anthropic-ai" in body \
-                or "google-extended" in body
+                or "ccbot" in body \
+                or "omgilibot" in body \
+                or "omgili" in body \
+                or "bytespider" in body
 
         except Exception as e:
             print(e, file=sys.stderr)  # Print the error to stderr

--- a/scrape.py
+++ b/scrape.py
@@ -33,6 +33,7 @@ def scrape_websites(websites):
                 or "ccbot" in body \
                 or "omgilibot" in body \
                 or "omgili" in body \
+                or "facebookbot" in body \
                 or "bytespider" in body
 
         except Exception as e:


### PR DESCRIPTION
Thanks for providing a sample of how to request spam tools not plagiarize one's site. It's been [useful for Lobste.rs](https://github.com/lobsters/lobsters/blob/d778ead68807323be4e8cf9756334a1d21826c05/public/robots.txt) and [the discussion](https://lobste.rs/s/ybowdq/great_gpt_firewall) turned up some more abusers.

I added these others to the sample and scraper. I didn't re-run the crawl because it sounds like you want to create a git history with monthly commits, but I can if you'd like it added to this PR.

I noticed `ccbot` was in the sample `robots.txt` but not present in `scrape.py`, so I added it.

I noticed `anthropic-ai` and `google-extended` swapped positions in the two files so I matched them. I think you should consider alphabetically sorting these for future convenience, but it seemed a little too far in the direction of a personal style choice to include in this PR.